### PR TITLE
Fix/set-fl_chart-version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   provider: ^6.1.2
   intl: ^0.20.1
   flutter_slidable: ^3.1.2
-  fl_chart: ^0.70.0
+  fl_chart: 0.70.0
   board_datetime_picker: 2.2.1
 
 dev_dependencies:


### PR DESCRIPTION
错误信息：
```
flutter build ios                                                                                                        
Building com.example.expenseLog for device (ios-release)...
Automatically signing iOS for device deployment using specified development team in Xcode project: ■■■■■■■■■■
Running Xcode build...
Xcode build done.                                            7.4s
Failed to build iOS app
Error (Xcode): lib/bar%20graph/bar_graph.dart:152:66: Error: No named parameter with the name 'axisSide'.
```
build的时候出现`No named parameter with the name 'axisSide'`
查了一下后发现是`fl_chart`的`0.70.1`之后版本把`axisSide`换成了直接代入`meta`